### PR TITLE
Arreglada la visualización de imágenes en distintas resoluciones

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -889,8 +889,7 @@ Screenshots
 }
 
 .screenshots figure img {
-    width: 100%;
-    height: 100%;
+    width: 260%;
     -webkit-transition: all 300ms ease-in-out;
     transition: all 300ms ease-in-out;
 }
@@ -1320,7 +1319,7 @@ hr {
 .image {
     display: inline-block;
     width: 100%;
-    height: 25vw;
+    max-height: 365px;
     background-position: center center;
     background-size: cover;
 }


### PR DESCRIPTION
He intentado que el carrousel se visualice de la mejor manera posible en distintas resoluciones jugando con el ancho y overlay de la imagen. Con el alto 100% como está ahora la imagen se deformaba y en los móviles era casi imposible navegar.
